### PR TITLE
Clean up comments

### DIFF
--- a/web/el.yml
+++ b/web/el.yml
@@ -1,4 +1,4 @@
-el: # el-GR:
+el:
   viewer:
     comment_on_twitter: 'Σχολιασμός στο Twitter'
     older: 'Παλαιότερα'

--- a/web/en.yml
+++ b/web/en.yml
@@ -3,7 +3,7 @@
 # This is the locale file for the Roon Viewer. The Viewer is the part of Roon
 # that shows users' blogs. Example: <http://sam.roon.io>
 #
-# Don't translate anything that starts with `#`. That is just a comment for
+# Don't translate anything that starts with "#". That is just a comment for
 # the translator! Please don't include them in your version.
 
 # Language code. Be sure this matches your file name (without the extension).

--- a/web/es.yml
+++ b/web/es.yml
@@ -1,4 +1,4 @@
-es: # Specifically South American Spanish
+es:
   viewer:
     comment_on_twitter: 'Coméntalo en Twitter'
     older: 'Lo viejo'

--- a/web/hi.yml
+++ b/web/hi.yml
@@ -1,4 +1,4 @@
-hi: # Hindi, India
+hi:
   viewer:
     comment_on_twitter: 'ट्विटर पर कॉमेंट'
     older: 'पुराने'


### PR DESCRIPTION
- Changed <code>&#96;#&#96;</code> to `"#"` (it's not code, it's comment).
- Removed comments from `el`, `es` and `hi` translations.
