### PR TITLE
A few grammar/spelling changes to the Croatian translation

### DIFF
--- a/web/hr.yml
+++ b/web/hr.yml
@@ -1,20 +1,20 @@
 hr:
   viewer:
-    comment_on_twitter: 'Komentiraj na Tviteru'
+    comment_on_twitter: 'Komentiraj na Twitteru'
     older: 'Starije'
     newer: 'Novije'
-    feed: 'Izvod vijesti'
-    like: 'Označi kao omiljeno'
+    feed: 'ATOM novosti'
+    like: 'Sviđa mi se'
     share: 'Podijeli'
     close: 'Zatvori'
     next_post: 'Sljedeći post'
     previous_post: 'Prethodni post'
-    no_posts: 'Nema postova.'
+    no_posts: 'Još nema postova'
     post_not_found:
       title: 'Post nije pronađen'
-      message: 'Možda ste ukucali pogrešnu adresu ili je post uklonjen.'
+      message: 'Možda ste ukucali krivu adresu ili je post uklonjen.'
     blog_not_found:
       title: 'Blog nije pronađen'
-      message: 'Možda ste ukucali pogrešni URL ili ovaj blog više ne postoji.'
+      message: 'Možda ste ukucali krivi URL ili ovaj blog više ne postoji.'
     title_by_author: '„%{title}“ od %{author}'
-    dont_share: 'Ne dijelite ovaj link'
+    dont_share: 'Nemojte dijeliti ovaj link'

--- a/web/hr.yml
+++ b/web/hr.yml
@@ -3,7 +3,7 @@ hr:
     comment_on_twitter: 'Komentiraj na Twitteru'
     older: 'Starije'
     newer: 'Novije'
-    feed: 'ATOM novosti'
+    feed: 'Atom novosti'
     like: 'Sviđa mi se'
     share: 'Podijeli'
     close: 'Zatvori'


### PR DESCRIPTION
'Izvod vijesti' is not a particularly good translation, and it would confuse a lot of people, so I believe it's better to use 'ATOM novosti' instead. Nobody uses 'izvod' for ATOM feeds.

Also, 'Označi kao omiljeno' is only used for marking posts as favourites, not liking, so I used 'Sviđa mi se' which is a better translation for 'Like', and it's used by Facebook.

I've changed 'pogrešni' to it's synonym 'krivi' because there our linguist are arguing about the spelling of it for years now. Is it 'pogrešni', 'pogrješni' or 'pofsjgnh', nobody knows for sure.

Croatian does not transcribe words fonetically like Serbian, so it isn't 'Tviter', it's 'Twitter'.

I also changed some bad constructions. Of course, zdroid is not to blame, as he's not really a native speaker of Croatian, which is a language that still doesn't have definitive grammar and spelling rules.
